### PR TITLE
Fix/windows support

### DIFF
--- a/src/git-branch-delete.js
+++ b/src/git-branch-delete.js
@@ -153,9 +153,9 @@ var isGitRepository = function () {
 };
 var getGitBranches = function () {
   var cmd =
-    "git for-each-ref --sort=committerdate refs/heads/ --format=%(HEAD):%(refname:short):::%(committerdate:relative):::%(committerdate:iso8601)";
+    "git for-each-ref --sort=committerdate refs/heads/ --format='%(HEAD):%(refname:short):::%(committerdate:relative):::%(committerdate:iso8601)'";
   var text = child_process.execSync(cmd, { encoding: "utf-8" });
-  var lines = text.split("\n");
+  var lines = text.replace(/'/ig,'').split("\n");
   var linesWithoutCurrentBranch = lines.filter(function (line) {
     return !line.startsWith("*:");
   });

--- a/src/git-branch-delete.js
+++ b/src/git-branch-delete.js
@@ -153,11 +153,11 @@ var isGitRepository = function () {
 };
 var getGitBranches = function () {
   var cmd =
-    "git for-each-ref --sort=committerdate refs/heads/ --format='%(HEAD) %(refname:short):::%(committerdate:relative):::%(committerdate:iso8601)'";
+    "git for-each-ref --sort=committerdate refs/heads/ --format=%(HEAD):%(refname:short):::%(committerdate:relative):::%(committerdate:iso8601)";
   var text = child_process.execSync(cmd, { encoding: "utf-8" });
   var lines = text.split("\n");
   var linesWithoutCurrentBranch = lines.filter(function (line) {
-    return !line.startsWith("* ");
+    return !line.startsWith("*:");
   });
   var branches = linesWithoutCurrentBranch.map(function (line) {
     var _a = line.substring(2).split(":::"),

--- a/src/git-branch-delete.ts
+++ b/src/git-branch-delete.ts
@@ -30,9 +30,9 @@ const isGitRepository = (): boolean => {
 
 const getGitBranches = (): GitBranch[] => {
   const cmd =
-    "git for-each-ref --sort=committerdate refs/heads/ --format=%(HEAD):%(refname:short):::%(committerdate:relative):::%(committerdate:iso8601)";
+    "git for-each-ref --sort=committerdate refs/heads/ --format='%(HEAD):%(refname:short):::%(committerdate:relative):::%(committerdate:iso8601)'";
   const text = child_process.execSync(cmd, { encoding: "utf-8" });
-  const lines: string[] = text.split("\n");
+  const lines: string[] = text.replace(/'/ig,'').split("\n");
   const linesWithoutCurrentBranch = lines.filter(
     (line) => !line.startsWith("*:")
   );

--- a/src/git-branch-delete.ts
+++ b/src/git-branch-delete.ts
@@ -30,11 +30,11 @@ const isGitRepository = (): boolean => {
 
 const getGitBranches = (): GitBranch[] => {
   const cmd =
-    "git for-each-ref --sort=committerdate refs/heads/ --format='%(HEAD) %(refname:short):::%(committerdate:relative):::%(committerdate:iso8601)'";
+    "git for-each-ref --sort=committerdate refs/heads/ --format=%(HEAD):%(refname:short):::%(committerdate:relative):::%(committerdate:iso8601)";
   const text = child_process.execSync(cmd, { encoding: "utf-8" });
   const lines: string[] = text.split("\n");
   const linesWithoutCurrentBranch = lines.filter(
-    (line) => !line.startsWith("* ")
+    (line) => !line.startsWith("*:")
   );
   const branches: GitBranch[] = linesWithoutCurrentBranch.map((line) => {
     const [name, lastCommitRelative, lastCommit] = line


### PR DESCRIPTION
On Windows, regardless if using Git Bash (MINGW64) or Node.js specific console, return value of `child_process.execSync(...)` is truncated at space. Proposed solution is using something different from space in the `git for-each-ref --format` command. 

**Please verify compatibility with other OS you are using.** 

Resolves #5 

Worth noting, that due to usage of `enquirer` package, tool won't work on Git Bash. The reason behind it - probable because Git Bash is not an interactive/TTY shell ([MINGW64 is not supported @ enquirer](https://github.com/enquirer/enquirer/issues/106#issuecomment-1113269738)).