### PR TITLE
Quote branch name in delete command

### DIFF
--- a/src/git-branch-delete.ts
+++ b/src/git-branch-delete.ts
@@ -93,7 +93,7 @@ const askForConfirmation = async (
 
 const deleteBranches = (branchesToDelete: string[]) => {
   for (const branchName of branchesToDelete) {
-    const command = `git branch -D ${branchName}`;
+    const command = `git branch -D '${branchName}'`;
     console.log(command);
     const result = child_process.execSync(command, { encoding: "utf-8" });
     console.log(result);


### PR DESCRIPTION
Fixes error when deleting, for example, a branch with parentheses `()` in its name:

```sh
git branch -D my/branch(test)
/bin/sh: -c: line 0: syntax error near unexpected token `('
/bin/sh: -c: line 0: `git branch -D my/branch(test)'
node:internal/errors:856
  const err = new Error(message);
              ^

Error: Command failed: git branch -D my/branch(test)
/bin/sh: -c: line 0: syntax error near unexpected token `('
/bin/sh: -c: line 0: `git branch -D my/branch(test)'

    at checkExecSyncError (node:child_process:841:11)
    at Object.execSync (node:child_process:912:15)
    at deleteBranches (/usr/local/lib/node_modules/git-branch-delete/build/git-branch-delete.js:125:36)
    at /usr/local/lib/node_modules/git-branch-delete/build/git-branch-delete.js:157:17
    at step (/usr/local/lib/node_modules/git-branch-delete/build/git-branch-delete.js:34:23)
    at Object.next (/usr/local/lib/node_modules/git-branch-delete/build/git-branch-delete.js:15:53)
    at fulfilled (/usr/local/lib/node_modules/git-branch-delete/build/git-branch-delete.js:6:58)
    at processTicksAndRejections (node:internal/process/task_queues:96:5) {
  status: 2,
  signal: null,
  output: [
    null,
    '',
    "/bin/sh: -c: line 0: syntax error near unexpected token `('\n" +
      "/bin/sh: -c: line 0: `git branch -D my/branch(test)'\n"
  ],
  pid: 96153,
  stdout: '',
  stderr: "/bin/sh: -c: line 0: syntax error near unexpected token `('\n" +
    "/bin/sh: -c: line 0: `git branch -D my/branch(test)'\n"
}
```